### PR TITLE
feat: require login on all views except excepted

### DIFF
--- a/purchases/exceptions.py
+++ b/purchases/exceptions.py
@@ -62,6 +62,22 @@ class TrackerRejectedUnknownCode(Error):
         )
 
 
+class TrackerInvalidApiKey(Error):
+    """Exception raised when API request indicates missing or invalid API key."""
+
+    def __init__(
+        self,
+        code,
+        message="Tracking API returned an unrecognized error code.",
+    ):
+        self.error_code = code
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self) -> str:
+        return f"{self.message}: {self.error_code}"
+
+
 class StatusCodeNotFound(Error):
     """Exception raised when status two-character code not found"""
 

--- a/purchases/models/models_data.py
+++ b/purchases/models/models_data.py
@@ -637,9 +637,6 @@ class Tracker(models.Model):
     def get_tracking_link(self):
         tracking_patterns = get_setting("TRACKER_PARAMS", ["trackingnumber"])
 
-        for pattern in tracking_patterns:
-            logger.info(f"{pattern}")
-
         try:
             path = furl(self.carrier.tracking_link)
 

--- a/purchases/tests.py
+++ b/purchases/tests.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 from http import HTTPStatus
 
 from django.contrib.auth.models import Permission, User
@@ -23,7 +24,7 @@ from purchases.views import tracking_webhook
 
 # from web_project.settings import AFTERSHIP_WEBHOOK_SECRET
 
-# from web_project.settings import _17TRACK_KEY
+# from web_project.settings import PYTRACK_17TRACK_KEY
 
 
 class PurchaseRequestTestModel(TestCase):
@@ -68,7 +69,7 @@ class PurchaseRequestTestModel(TestCase):
 #         response = self.client.get(reverse("new_pr"))
 #         self.assertEqual(response.status_code, 200)
 
-# @override_settings(_17TRACK_KEY="abc123")
+# @override_settings(PYTRACK_17TRACK_KEY="abc123")
 # class TrackingWebhookTests(TestCase):
 #     def setUp(self):
 #         self.client = Client(enforce_csrf_checks=True)

--- a/web_project/fields.py
+++ b/web_project/fields.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from web_project import form_fields
-from web_project.helpers import plog
 
 logger = logging.getLogger(__name__)
 log_kwargs = {
@@ -62,7 +61,5 @@ class SimplePercentageField(models.DecimalField):
             decimal_places=self.decimal_places - 2,
         )
         defaults.update(kwargs)
-
-        plog(text="Decimal Places", value=kwargs["decimal_places"], **log_kwargs)
 
         return super().formfield(**defaults)

--- a/web_project/form_fields.py
+++ b/web_project/form_fields.py
@@ -33,7 +33,6 @@ class SimplePercentageField(forms.DecimalField):
         **kwargs,
     ):
         log_kwargs["path"] = f"{logger.name}.SimplePercentageField"
-        plog(text="Decimal Places", value=decimal_places, **log_kwargs)
         if "widget" not in kwargs:
             step = 10 ** (-1 * decimal_places)
             kwargs["widget"] = forms.NumberInput(
@@ -72,13 +71,8 @@ class SimplePercentageField(forms.DecimalField):
 
     def prepare_value(self, value):
         log_kwargs["path"] = f"{logger.name}.prepare_value"
-        value_type = type(value) if settings.DEBUG else None
-        plog(text=f"incoming value [{value_type}]", value=value, **log_kwargs)
 
         val = super().prepare_value(value)
-        val_type = type(val) if settings.DEBUG else None
-
-        plog(text=f"after super() val [{val_type}]", value=val, **log_kwargs)
 
         if isinstance(val, Percent):
             return val.per_hundred

--- a/web_project/settings/base.py
+++ b/web_project/settings/base.py
@@ -114,6 +114,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "web_project.helpers.LoginRequiredMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
@@ -353,7 +354,7 @@ CRISPY_TEMPLATE_PACK = "bootstrap5"
 # CUSTOM
 # -------------------------------------------------------------------
 
-_17TRACK_KEY = env.str("_17TRACK_KEY", default="!!!MISSING API KEY!!!")
+PYTRACK_17TRACK_KEY = env.str("PYTRACK_17TRACK_KEY", default="!!!MISSING API KEY!!!")
 
 MESSAGE_TAGS = {
     message_constants.SUCCESS: "alert alert-success",
@@ -367,4 +368,10 @@ TRACKER_PARAMS = [
     "trackingnumber",
     "tracking_number",
     "strorigtracknum",
+]
+
+ALLOWED_ANONYMOUS_VIEWS = [
+    "LoginView",
+    "LogoutView",
+    "PasswordResetView",
 ]

--- a/web_project/settings/local.py
+++ b/web_project/settings/local.py
@@ -1,5 +1,5 @@
 from .base import *  # noqa: F40
-from .base import _17TRACK_KEY, env  # noqa: F40
+from .base import env
 
 # GENERAL
 # --------------------------------------------------------

--- a/web_project/settings/production.py
+++ b/web_project/settings/production.py
@@ -8,7 +8,7 @@ except ImportError:
     logging.warning("`sentry_sdk` not installed")
 
 from .base import *  # noqa: F40
-from .base import _17TRACK_KEY, env
+from .base import env
 
 # from sentry_sdk.integrations.redis import RedisIntegration
 


### PR DESCRIPTION
- created `LoginRequiredMiddleware` to make all views `login_required` by default
- setting `ALLOWED_ANONYMOUS_VIEWS` for views outside our code to be allowed
- use `login_exempt` decorator for views in this project, typically

- fix unhandled exceptions when 17Track API key is not set or invalid