### PR TITLE
Vendor order datepicker

### DIFF
--- a/purchases/forms.py
+++ b/purchases/forms.py
@@ -73,6 +73,10 @@ class AddVendorOrderForm(forms.ModelForm):
     class Meta:
         model = VendorOrder
         fields = "__all__"
+        widgets = {
+            "order_placed": DatePickerInput(),
+            "invoice_due_date": DatePickerInput(),
+        }
 
 
 # class AddRequisitionerForm(forms.ModelForm):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 crispy-bootstrap5==0.7
 Django==4.0.8  # pyup: < 4.1
 django[argon2]
-django-bootstrap-datepicker-plus==4.0.0
+django-bootstrap-datepicker-plus==5.0.0
 # django-crispy-forms>=1.14.0
 # django-constance>=2.9.0
 django-debug-toolbar==3.7.0


### PR DESCRIPTION
Change widgets for date fields on `AddVendorOrderForm`. Manually update `datepicker-plus` to 5.0.0 to match main for testing purposes.