### PR TITLE
fix: add `linebreaks` to `VendorOrder.notes`

### DIFF
--- a/purchases/templates/purchases/vendororder/vendororder_detail.html
+++ b/purchases/templates/purchases/vendororder/vendororder_detail.html
@@ -91,7 +91,7 @@
         </table>
         {% if object.notes %}
           <p>
-            {{ object.notes }}
+            {{ object.notes|linebreaks }}
           </p>
         {% endif %}
       </div>


### PR DESCRIPTION
allows for formatting to work properly