### PR TITLE
change from `django-modelclone` to `django-modelclone-next`

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ django-environ>=0.8.1
 django-gravatar2 @ git+https://github.com/wsutc/django-gravatar@master
 django-import-export>=2.8.0
 django-listview-filters==0.0.1b1.dev1
-django-modelclone @ git+https://github.com/xuhcc/django-modelclone.git@6234f3d03f7ec70f95ef99f2d6171fa1d045787a
+django-modelclone-next==0.8.2
 django-money>=2.1.1
 django-phonenumber-field>=6.1.0
 django-select2>=7.10.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -11,5 +11,5 @@ pre-commit>=2.20.0
 # Django
 # ------------------------------------------------------------
 django-mysql==4.9.0
-model-bakery>=1.5.0
+model-bakery==1.12.0
 mysqlclient==2.1.1


### PR DESCRIPTION
start using an official package that has been renamed to `django-modelclone-next`

I was using it before, but from the github source, now it's an official package after 0.7.1